### PR TITLE
docs: add reference to Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ $ make
 $ ./bin/gocatcli --help
 ```
 
+It's also available on [Nix](https://github.com/NixOS/nixpkgs) (unstable channel only, for now). If you have Nix installed, one way you can try it out is like this:
+``` bash
+nix-shell -p gocatcli
+```
+
 # Usage
 
 The primary use of gocatcli is to index your data (external hardrives, etc) into a catalog


### PR DESCRIPTION
It just became available in nixpkgs, so here is the docs PR as promised.

This is the actual derivation (package definition): https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/go/gocatcli/package.nix

That contains everything necessary to add a new package like gocatcli to nixpkgs. Thought that you might be interested in how that actually looks.

Thanks again!