### PR TITLE
find: add -i/--ignore-case flag for case-insensitive pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # gocatcli
 
-* Case intensive find option now - just use -i Switch nothing else changed!
-
 
 [![Tests Status](https://github.com/deadc0de6/gocatcli/workflows/tests/badge.svg)](https://github.com/deadc0de6/gocatcli/actions)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
@@ -14,6 +12,8 @@ Did you ever wanted to find back that specific file that should be on one of you
 You usually go through all of them hoping to find the right one on the first try?
 `gocatcli` indexes external media in a catalog file and allows to quickly find
 specific files or even navigate in the catalog as if it was a mounted drive.
+
+* Case intensive find option now - just use -i Switch nothing else changed!
 
 Features:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # gocatcli
 
+* Case intensive find option now - just use -i Switch nothing else changed!
+
+
 [![Tests Status](https://github.com/deadc0de6/gocatcli/workflows/tests/badge.svg)](https://github.com/deadc0de6/gocatcli/actions)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
 

--- a/internal/commands/find.go
+++ b/internal/commands/find.go
@@ -27,9 +27,10 @@ var (
 		RunE:   find,
 	}
 
-	findOptStart  string
-	findOptFormat string
-	findOptDepth  int
+	findOptStart      string
+	findOptFormat     string
+	findOptDepth      int
+	findOptIgnoreCase bool
 )
 
 func init() {
@@ -39,6 +40,7 @@ func init() {
 	hlp := fmt.Sprintf("output format (%s)", strings.Join(stringer.GetSupportedFormats(false, true), ","))
 	findCmd.PersistentFlags().StringVarP(&findOptFormat, "format", "f", "native", hlp)
 	findCmd.PersistentFlags().IntVarP(&findOptDepth, "depth", "D", -1, "max depth")
+	findCmd.PersistentFlags().BoolVarP(&findOptIgnoreCase, "ignore-case", "i", false, "case insensitive pattern matching")
 }
 
 func find(_ *cobra.Command, args []string) error {
@@ -111,11 +113,20 @@ func patchFindPattern(pattern string) string {
 func matchNodes(t *tree.Tree, startNode node.Node, patt string, prt stringer.Stringer) {
 	var cnt int64
 
+	matchPatt := patt
+	if findOptIgnoreCase {
+		matchPatt = strings.ToLower(matchPatt)
+	}
+
 	t0 := time.Now()
 	callback := func(n node.Node, _ int, _ node.Node) bool {
 		path := n.GetPath()
 		log.Debugf("trying to match path \"%s\" against pattern \"%s\"", path, patt)
-		if helpers.PathMatch(patt, path) {
+		matchPath := path
+		if findOptIgnoreCase {
+			matchPath = strings.ToLower(matchPath)
+		}
+		if helpers.PathMatch(matchPatt, matchPath) {
 			log.Debugf("\"%s\" matches \"%s\"", path, patt)
 			prt.Print(n, 0)
 			cnt++

--- a/tests-ng/test-find.sh
+++ b/tests-ng/test-find.sh
@@ -71,6 +71,22 @@ cnt=$(wc -l "${out}" | awk '{print $1}')
 [ "${cnt}" != "${expected}" ] && echo "expecting ${expected} lines (${cnt})" && exit 1
 
 # ===================================================
+title ">>> test find case sensitive by default <<<"
+"${bin}" --debug find -c "${catalog}" 'NAV*' | sed -e 's/\x1b\[[0-9;]*m//g' > "${out}"
+cnt=$(wc -l "${out}" | awk '{print $1}')
+[ "${cnt}" != "0" ] && echo "expecting 0 lines (case sensitive), got ${cnt}" && exit 1
+
+# ===================================================
+title ">>> test find with --ignore-case <<<"
+"${bin}" --debug find -c "${catalog}" -i 'NAV*' | sed -e 's/\x1b\[[0-9;]*m//g' > "${out}"
+expected=$(find "${cur}/../internal" ! -path '*/.git/*' -iname 'nav*' | wc -l)
+cnt=$(wc -l "${out}" | awk '{print $1}')
+[ "${cnt}" != "${expected}" ] && echo "expecting ${expected} lines (${cnt})" && exit 1
+grep '^internal/commands/nav.go.*' "${out}" || (echo "bad content" && exit 1)
+grep '^internal/navigator.*' "${out}" || (echo "bad content" && exit 1)
+grep '^internal/navigator/navigator.go.*' "${out}" || (echo "bad content" && exit 1)
+
+# ===================================================
 title ">>> test find with multiple args <<<"
 "${bin}" --debug find -c "${catalog}" storage tree | sed -e 's/\x1b\[[0-9;]*m//g' > "${out}"
 expected=$(find "${cur}/../internal" | grep -c 'storage\|tree')


### PR DESCRIPTION
Adds -i/--ignore-case flag to find for case-insensitive pattern matching. File/folder naming in real-world collections is often inconsistently cased (e.g. "Need For Speed" vs "Need for Speed"), and the existing glob matcher is case-sensitive by default, causing searches to silently miss valid matches.
Tested locally — builds clean, verified against a real catalog, updated tests-ng/test-find.sh accordingly.